### PR TITLE
Some small fixes to unblock playing and previous song button 

### DIFF
--- a/app/scripts/services/SongPlayer.js
+++ b/app/scripts/services/SongPlayer.js
@@ -51,7 +51,7 @@
 		* @function getSongIndex 
 		* @desc Grabing the index of the songs using currentAlbum which stores getAlbum() from the Fixtures.js file
 		*/
-		var getSongIndex = function () {
+		var getSongIndex = function (song) {
 			return currentAlbum.songs.indexOf(song);
 		};
 		
@@ -68,7 +68,6 @@
 				playSong(song);
 			} else if (SongPlayer.currentSong === song) {
 					if (currentBuzzObject.isPaused()) {
-						console.log(isPaused());
 						playSong(song);
 					}
 				}
@@ -94,7 +93,7 @@
 			if (currentSongIndex < 0) {
 				stopSong(SongPlayer.currentSong);
 			} else {
-				var song = currentAlbum.song[currentSongIndex];
+				var song = currentAlbum.songs[currentSongIndex];
 				setSong(song);
 				playSong(song);
 			}


### PR DESCRIPTION
# What is this?

Per your comment on #7, I went and fixed some small mistakes to help unlock you.

# Error Message
```bash
ReferenceError: song is not defined
    at getSongIndex (SongPlayer.js:55)
    at Object.SongPlayer.SongPlayer.next (SongPlayer.js:107)
    at fn (eval at compile (angular.js:14817), <anonymous>:4:351)
    at b (angular.js:15906)
    at e (angular.js:25885)
    at b.$eval (angular.js:17682)
    at b.$apply (angular.js:17782)
    at HTMLAnchorElement.<anonymous> (angular.js:25890)
    at HTMLAnchorElement.dispatch (jquery-2.1.4.min.js:3)
    at HTMLAnchorElement.r.handle (jquery-2.1.4.min.js:3)
```

Great job on the explanation, with screenshots. The ability to explain your error/issues is a skill that not everyone does well. You reply is great example and you should strive to do that everytime 💯 
