### PR TITLE
fixes typos

### DIFF
--- a/app/templates/album.html
+++ b/app/templates/album.html
@@ -1,6 +1,6 @@
 <main class="album-view container narrow">
 	<section class="clearfix">
-		<div class="colum half">
+		<div class="column half">
 			<img src="{{ album.albumData.albumArtUrl }}" class="album-cover-art">
 		</div>
 		<div class="album-view-details column half">
@@ -10,7 +10,7 @@
 		</div>
 	</section>
 	
-	<table class="album-view-list">
+	<table class="album-view-song-list">
 		<tr class="album-view-song-item" ng-mouseover="hovered = true" ng-mouseleave="hovered = false" ng-repeat="song in album.albumData.songs">
 			<td class="song-item-number">
 				<span ng-show="!song.playing && !hovered">{{ $index + 1}}</span>


### PR DESCRIPTION
Something so simple but it was completely breaking your CSS. Be sure to to check spelling when stuff looks broken.

Before: 
<img width="1420" alt="screenshot 2016-12-16 15 25 11" src="https://cloud.githubusercontent.com/assets/5713670/21281717/e078a9d0-c3a3-11e6-93ee-23fd82fd4ad7.png">

After:

<img width="1347" alt="screenshot 2016-12-16 15 24 40" src="https://cloud.githubusercontent.com/assets/5713670/21281714/ddcfc452-c3a3-11e6-8a07-5cdc2412905e.png">

 